### PR TITLE
Update to Zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache/
+.zig-cache/
 zig-out/

--- a/build.zig
+++ b/build.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
-    _ = b.addModule("fp", .{ .source_file = .{ .path = "src/main.zig" } });
+    _ = b.addModule("fp", .{ .root_source_file = b.path("src/main.zig") });
 
     const main_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .optimize = optimize,
     });
     const run_tests = b.addRunArtifact(main_tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = "zigfp",
+    .version = "0.0.1",
+
+    .minimum_zig_version = "0.13.0",
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+        "src",
+    },
+}


### PR DESCRIPTION
This commit brings everything up to the 0.13.0 release of Zig. I considered bringing it up to Zig master, or a nominated version (like mach), but figured it'd be a good idea to have them all as their own commits, if at all.

Most of the changes related to how `std.fmt` has reorganized some of the float formatting stuff.